### PR TITLE
Implémente un MVP blind test (Node.js + WebSocket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
-# Blind Test App – Spécification MVP simple et économique
+# Blind Test App – MVP implémenté (Node.js + WebSocket)
 
-Ce dépôt contient une proposition de **MVP blind test** pensée pour :
-- un accès mobile (Android/iOS) via navigateur,
-- une gestion en temps réel (buzzer + score),
-- une architecture Azure la plus simple possible,
-- un coût réduit sans base de données managée coûteuse.
+Prototype fonctionnel pour un blind test temps réel avec :
+- interface joueur (inscription + buzzer),
+- interface admin (création de session, start/stop, décision +1/-1),
+- classement mis à jour en direct via WebSocket,
+- stockage en mémoire (MVP).
 
-## Document principal
-- `docs/blind-test-app-plan.md`
+## Lancer le projet
 
-## Points clés
-- 10 à 100 joueurs par partie.
-- Accès via QR code.
-- Classement consultable en continu par tous les joueurs.
-- Interface administrateur pour valider/refuser les buzz (+1 / -1).
+```bash
+npm install
+npm start
+```
+
+Puis ouvrir `http://localhost:3000`.
+
+## Variables d'environnement
+- `PORT` (défaut `3000`)
+- `ADMIN_PASSWORD` (défaut `admin123`)
+
+## API disponible
+
+### HTTP
+- `POST /admin/login`
+- `POST /sessions` (admin)
+- `POST /sessions/:id/start` (admin)
+- `POST /sessions/:id/stop` (admin)
+- `POST /sessions/:id/players`
+- `POST /sessions/:id/buzz`
+- `POST /sessions/:id/decision` (admin)
+- `GET /sessions/:id/ranking`
+
+### WebSocket
+Connexion sur `ws://host:port/?sessionId=<SESSION_ID>`.
+
+Événements émis :
+- `session.started`
+- `buzz.locked`
+- `buzz.decided`
+- `ranking.updated`
+- `session.stopped`
+
+## Notes
+- Pas de persistance disque/DB : redémarrage serveur = perte des sessions.
+- Cette base couvre le MVP et peut ensuite être branchée sur Azure App Service + Static Web Apps.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "blind-test-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "node --watch server/index.js",
+    "check": "node --check server/index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ws": "^8.18.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blind Test MVP</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 1rem; max-width: 800px; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+      button { padding: .7rem 1rem; border-radius: 6px; border: 1px solid #ccc; cursor: pointer; }
+      .buzz { font-size: 1.5rem; width: 100%; padding: 2rem; }
+      input { padding: .6rem; margin-right: .4rem; }
+      #log { font-family: monospace; font-size: .9rem; background: #f7f7f7; padding: .75rem; white-space: pre-wrap; }
+      table { width: 100%; border-collapse: collapse; }
+      td, th { border-bottom: 1px solid #eee; padding: .4rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Blind Test MVP</h1>
+
+    <div class="card">
+      <h2>Connexion</h2>
+      <label>Session ID <input id="sessionId" /></label>
+      <button id="connectBtn">Connecter WS</button>
+    </div>
+
+    <div class="card">
+      <h2>Joueur</h2>
+      <input id="firstName" placeholder="Prénom" />
+      <input id="lastName" placeholder="Nom" />
+      <button id="joinBtn">Rejoindre</button>
+      <button class="buzz" id="buzzBtn">BUZZER</button>
+      <p>Player ID: <span id="playerId">-</span></p>
+    </div>
+
+    <div class="card">
+      <h2>Admin</h2>
+      <input id="adminPassword" type="password" placeholder="Mot de passe admin" />
+      <button id="loginBtn">Login</button>
+      <button id="createSessionBtn">Créer session</button>
+      <button id="startBtn">Démarrer</button>
+      <button id="stopBtn">Stop</button>
+      <button id="acceptBtn">Valider +1</button>
+      <button id="rejectBtn">Refuser -1</button>
+      <p>Token: <span id="adminToken">-</span></p>
+    </div>
+
+    <div class="card">
+      <h2>Classement</h2>
+      <table>
+        <thead><tr><th>Joueur</th><th>Score</th></tr></thead>
+        <tbody id="rankingBody"></tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h2>Logs</h2>
+      <div id="log"></div>
+    </div>
+
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,108 @@
+const state = {
+  sessionId: '',
+  playerId: '',
+  adminToken: '',
+  ws: null
+};
+
+const byId = (id) => document.getElementById(id);
+const logEl = byId('log');
+
+function log(message) {
+  logEl.textContent = `${new Date().toLocaleTimeString()} - ${message}\n${logEl.textContent}`;
+}
+
+function setRanking(ranking) {
+  const body = byId('rankingBody');
+  body.innerHTML = ranking
+    .map((entry) => `<tr><td>${entry.firstName} ${entry.lastName}</td><td>${entry.score}</td></tr>`)
+    .join('');
+}
+
+async function api(path, method = 'GET', payload) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (state.adminToken) {
+    headers.Authorization = `Bearer ${state.adminToken}`;
+  }
+
+  const response = await fetch(path, {
+    method,
+    headers,
+    body: payload ? JSON.stringify(payload) : undefined
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || 'Erreur API');
+  }
+
+  return data;
+}
+
+byId('connectBtn').onclick = () => {
+  state.sessionId = byId('sessionId').value;
+  state.ws?.close();
+  state.ws = new WebSocket(`${location.origin.replace('http', 'ws')}?sessionId=${state.sessionId}`);
+
+  state.ws.onopen = () => log('WebSocket connecté');
+  state.ws.onmessage = (event) => {
+    const { event: type, payload } = JSON.parse(event.data);
+    log(`${type}: ${JSON.stringify(payload)}`);
+    if (type === 'ranking.updated') {
+      setRanking(payload.ranking);
+    }
+  };
+  state.ws.onclose = () => log('WebSocket fermé');
+};
+
+byId('loginBtn').onclick = async () => {
+  const data = await api('/admin/login', 'POST', { password: byId('adminPassword').value });
+  state.adminToken = data.token;
+  byId('adminToken').textContent = state.adminToken;
+  log('Admin connecté');
+};
+
+byId('createSessionBtn').onclick = async () => {
+  const data = await api('/sessions', 'POST');
+  state.sessionId = data.id;
+  byId('sessionId').value = state.sessionId;
+  log(`Session créée: ${data.id} (code ${data.code})`);
+};
+
+byId('startBtn').onclick = async () => {
+  await api(`/sessions/${state.sessionId}/start`, 'POST');
+  log('Session démarrée');
+};
+
+byId('stopBtn').onclick = async () => {
+  await api(`/sessions/${state.sessionId}/stop`, 'POST');
+  log('Session stoppée');
+};
+
+byId('joinBtn').onclick = async () => {
+  const data = await api(`/sessions/${state.sessionId}/players`, 'POST', {
+    firstName: byId('firstName').value,
+    lastName: byId('lastName').value
+  });
+
+  state.playerId = data.playerId;
+  byId('playerId').textContent = state.playerId;
+  log(`Joueur inscrit: ${state.playerId}`);
+};
+
+byId('buzzBtn').onclick = async () => {
+  await api(`/sessions/${state.sessionId}/buzz`, 'POST', { playerId: state.playerId });
+  log('Buzz envoyé');
+};
+
+byId('acceptBtn').onclick = async () => {
+  const data = await api(`/sessions/${state.sessionId}/decision`, 'POST', { decision: 'accepted' });
+  setRanking(data.ranking);
+  log('Décision: accepted');
+};
+
+byId('rejectBtn').onclick = async () => {
+  const data = await api(`/sessions/${state.sessionId}/decision`, 'POST', { decision: 'rejected' });
+  setRanking(data.ranking);
+  log('Décision: rejected');
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,215 @@
+import crypto from 'node:crypto';
+import express from 'express';
+import { WebSocketServer } from 'ws';
+
+const app = express();
+const port = process.env.PORT || 3000;
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin123';
+
+app.use(express.json());
+app.use(express.static('public'));
+
+const sessions = new Map();
+const sessionSockets = new Map();
+const adminTokens = new Set();
+
+const uuid = () => crypto.randomUUID();
+
+function code() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+function ranking(session) {
+  return [...session.players].sort((a, b) => b.score - a.score || a.joinedAt - b.joinedAt);
+}
+
+function socketGroup(sessionId) {
+  if (!sessionSockets.has(sessionId)) {
+    sessionSockets.set(sessionId, new Set());
+  }
+
+  return sessionSockets.get(sessionId);
+}
+
+function broadcast(sessionId, event, payload = {}) {
+  const message = JSON.stringify({ event, payload });
+  for (const ws of socketGroup(sessionId)) {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(message);
+    }
+  }
+}
+
+function mustBeAdmin(req, res, next) {
+  const token = req.headers.authorization?.replace('Bearer ', '');
+  if (!token || !adminTokens.has(token)) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  next();
+}
+
+function getSession(req, res) {
+  const session = sessions.get(req.params.id);
+  if (!session) {
+    res.status(404).json({ error: 'session_not_found' });
+    return null;
+  }
+
+  return session;
+}
+
+app.post('/admin/login', (req, res) => {
+  const { password } = req.body ?? {};
+  if (password !== ADMIN_PASSWORD) {
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+
+  const token = uuid();
+  adminTokens.add(token);
+  res.json({ token });
+});
+
+app.post('/sessions', mustBeAdmin, (_req, res) => {
+  const id = uuid();
+  const newSession = {
+    id,
+    code: code(),
+    status: 'waiting',
+    buzzLocked: false,
+    currentBuzzPlayerId: null,
+    players: []
+  };
+
+  sessions.set(id, newSession);
+  res.status(201).json(newSession);
+});
+
+app.post('/sessions/:id/start', mustBeAdmin, (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  session.status = 'running';
+  broadcast(session.id, 'session.started', { sessionId: session.id });
+  res.json({ ok: true, status: session.status });
+});
+
+app.post('/sessions/:id/stop', mustBeAdmin, (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  session.status = 'stopped';
+  session.buzzLocked = true;
+  broadcast(session.id, 'session.stopped', { sessionId: session.id });
+  res.json({ ok: true, status: session.status });
+});
+
+app.post('/sessions/:id/players', (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  const { firstName, lastName } = req.body ?? {};
+  if (!firstName || !lastName) {
+    return res.status(400).json({ error: 'missing_name' });
+  }
+
+  const player = {
+    id: uuid(),
+    firstName,
+    lastName,
+    joinedAt: Date.now(),
+    score: 0
+  };
+
+  session.players.push(player);
+  res.status(201).json({ playerId: player.id, sessionId: session.id });
+});
+
+app.post('/sessions/:id/buzz', (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  const { playerId } = req.body ?? {};
+  const player = session.players.find((entry) => entry.id === playerId);
+  if (!player) {
+    return res.status(404).json({ error: 'player_not_found' });
+  }
+
+  if (session.status !== 'running') {
+    return res.status(409).json({ error: 'session_not_running' });
+  }
+
+  if (session.buzzLocked) {
+    return res.status(409).json({ error: 'buzz_locked', currentBuzzPlayerId: session.currentBuzzPlayerId });
+  }
+
+  session.buzzLocked = true;
+  session.currentBuzzPlayerId = player.id;
+
+  broadcast(session.id, 'buzz.locked', {
+    playerId: player.id,
+    playerName: `${player.firstName} ${player.lastName}`
+  });
+
+  res.json({ accepted: true, playerId: player.id });
+});
+
+app.post('/sessions/:id/decision', mustBeAdmin, (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  const { decision } = req.body ?? {};
+  if (!['accepted', 'rejected'].includes(decision)) {
+    return res.status(400).json({ error: 'invalid_decision' });
+  }
+
+  const player = session.players.find((entry) => entry.id === session.currentBuzzPlayerId);
+  if (!player) {
+    return res.status(409).json({ error: 'no_current_buzz' });
+  }
+
+  player.score += decision === 'accepted' ? 1 : -1;
+  const rank = ranking(session);
+
+  broadcast(session.id, 'buzz.decided', {
+    playerId: player.id,
+    decision,
+    score: player.score
+  });
+
+  broadcast(session.id, 'ranking.updated', { ranking: rank });
+
+  session.buzzLocked = false;
+  session.currentBuzzPlayerId = null;
+
+  res.json({ ok: true, ranking: rank });
+});
+
+app.get('/sessions/:id/ranking', (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  res.json({ ranking: ranking(session), status: session.status });
+});
+
+const server = app.listen(port, () => {
+  console.log(`Blind test server listening on :${port}`);
+});
+
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', (ws, req) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const sessionId = url.searchParams.get('sessionId');
+  if (!sessionId || !sessions.has(sessionId)) {
+    ws.close(1008, 'missing_or_invalid_session');
+    return;
+  }
+
+  const peers = socketGroup(sessionId);
+  peers.add(ws);
+
+  ws.on('close', () => {
+    peers.delete(ws);
+  });
+});


### PR DESCRIPTION
### Motivation
- Fournir un prototype fonctionnel de blind test temps réel accessible depuis un navigateur mobile avec un backend simple et peu coûteux. 
- Gérer le flux buzzer + arbitrage admin (+1 / -1) et diffuser le classement en direct sans dépendance à une base de données managée. 
- Offrir une base minimale prête à être déployée (front statique + service Node.js) pour itérations ultérieures.

### Description
- Ajout d'un serveur Node.js `server/index.js` utilisant `express` et `ws` qui stocke l'état des sessions en mémoire et broadcaste les événements WebSocket (`session.started`, `buzz.locked`, `buzz.decided`, `ranking.updated`, `session.stopped`).
- Implémentation des routes HTTP du MVP : `POST /admin/login`, `POST /sessions`, `POST /sessions/:id/start`, `POST /sessions/:id/stop`, `POST /sessions/:id/players`, `POST /sessions/:id/buzz`, `POST /sessions/:id/decision`, et `GET /sessions/:id/ranking`.
- Ajout d'une interface client simple `public/index.html` + `public/main.js` qui gère la connexion WebSocket, l'inscription des joueurs, le buzzer, les actions admin et l'affichage du classement en temps réel.
- Ajout de `package.json` avec scripts `start`, `dev`, `check` et dépendances déclarées, et mise à jour du `README.md` avec instructions d'exécution et documentation API/WebSocket.

### Testing
- `node --check server/index.js` exécuté avec succès et sans erreur de syntaxe. 
- `node --check public/main.js` exécuté avec succès et sans erreur de syntaxe. 
- `npm install` a échoué dans cet environnement avec une erreur `403 Forbidden` provenant du registre npm, ce qui empêche l'installation automatique des dépendances ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f3b39e70832ab62a17610642f669)