### PR TITLE
Admin back-office, player join flow, WS enhancements and scoring/round features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# Blind Test App – MVP implémenté (Node.js + WebSocket)
+# Blind Test App – MVP (Node.js + WebSocket)
 
 Prototype fonctionnel pour un blind test temps réel avec :
-- interface joueur (inscription + buzzer),
-- interface admin (création de session, start/stop, décision +1/-1),
-- classement mis à jour en direct via WebSocket,
+- interface joueur dédiée (`/`),
+- interface admin dédiée (`/admin`) protégée par mot de passe serveur,
+- pseudo joueur unique par partie,
+- création de partie, démarrage/arrêt, lancement de manche musicale,
+- suivi des joueurs connectés,
+- notification du premier buzz avec proposition,
+- validation/refus par l'admin et classement en direct via WebSocket,
+- annonce du gagnant en fin de partie,
 - stockage en mémoire (MVP).
 
 ## Lancer le projet
@@ -13,7 +18,9 @@ npm install
 npm start
 ```
 
-Puis ouvrir `http://localhost:3000`.
+Puis ouvrir :
+- Joueur : `http://localhost:3000/`
+- Admin : `http://localhost:3000/admin`
 
 ## Variables d'environnement
 - `PORT` (défaut `3000`)
@@ -21,26 +28,34 @@ Puis ouvrir `http://localhost:3000`.
 
 ## API disponible
 
-### HTTP
+### Admin (protégée)
 - `POST /admin/login`
-- `POST /sessions` (admin)
-- `POST /sessions/:id/start` (admin)
-- `POST /sessions/:id/stop` (admin)
-- `POST /sessions/:id/players`
+- `POST /admin/logout`
+- `GET /admin/auth-status`
+- `POST /admin/api/sessions`
+- `POST /admin/api/sessions/:id/start`
+- `POST /admin/api/sessions/:id/stop`
+- `POST /admin/api/sessions/:id/rounds`
+- `GET /admin/api/sessions/:id/stats`
+- `POST /admin/api/sessions/:id/decision`
+
+### Joueur
+- `POST /sessions/join` (code session + pseudo unique)
 - `POST /sessions/:id/buzz`
-- `POST /sessions/:id/decision` (admin)
 - `GET /sessions/:id/ranking`
 
 ### WebSocket
-Connexion sur `ws://host:port/?sessionId=<SESSION_ID>`.
+Connexion sur `ws://host:port/?sessionId=<SESSION_ID>&playerId=<PLAYER_ID>`.
 
 Événements émis :
 - `session.started`
+- `session.stopped` (inclut le gagnant)
+- `round.started`
+- `players.connected.updated`
 - `buzz.locked`
 - `buzz.decided`
 - `ranking.updated`
-- `session.stopped`
 
 ## Notes
 - Pas de persistance disque/DB : redémarrage serveur = perte des sessions.
-- Cette base couvre le MVP et peut ensuite être branchée sur Azure App Service + Static Web Apps.
+- Auth admin gérée côté serveur via cookie HTTP-only après login.

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,154 @@
+const state = {
+  sessionId: '',
+  sessionCode: '',
+  ws: null
+};
+
+const byId = (id) => document.getElementById(id);
+const logEl = byId('log');
+
+function log(message) {
+  logEl.textContent = `${new Date().toLocaleTimeString()} - ${message}\n${logEl.textContent}`;
+}
+
+function setRanking(ranking) {
+  const body = byId('rankingBody');
+  body.innerHTML = ranking
+    .map((entry) => `<tr><td>${entry.displayName}</td><td>${entry.score}</td></tr>`)
+    .join('');
+}
+
+function setStats(payload) {
+  if (typeof payload.connectedPlayers === 'number') {
+    byId('connectedPlayers').textContent = String(payload.connectedPlayers);
+  }
+  if (typeof payload.registeredPlayers === 'number') {
+    byId('registeredPlayers').textContent = String(payload.registeredPlayers);
+  }
+}
+
+function setBuzz(payload) {
+  byId('buzzPlayer').textContent = payload?.playerName ?? '-';
+  byId('buzzProposal').textContent = payload?.proposal ? JSON.stringify(payload.proposal) : '-';
+}
+
+async function api(path, method = 'GET', payload) {
+  const response = await fetch(path, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: payload ? JSON.stringify(payload) : undefined
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.error || 'Erreur API');
+  }
+
+  return data;
+}
+
+function connectWs() {
+  if (!state.sessionId) {
+    return;
+  }
+
+  state.ws?.close();
+  const wsUrl = new URL(location.origin.replace('http', 'ws'));
+  wsUrl.searchParams.set('sessionId', state.sessionId);
+  wsUrl.searchParams.set('admin', '1');
+
+  state.ws = new WebSocket(wsUrl);
+  state.ws.onopen = () => log('WebSocket admin connecté');
+  state.ws.onclose = () => log('WebSocket admin fermé');
+  state.ws.onmessage = (event) => {
+    const { event: type, payload } = JSON.parse(event.data);
+    log(`${type}: ${JSON.stringify(payload)}`);
+
+    if (type === 'ranking.updated') {
+      setRanking(payload.ranking);
+    }
+
+    if (type === 'players.connected.updated') {
+      setStats(payload);
+    }
+
+    if (type === 'buzz.locked') {
+      setBuzz(payload);
+    }
+  };
+}
+
+async function refreshStats() {
+  if (!state.sessionId) {
+    return;
+  }
+
+  const data = await api(`/admin/api/sessions/${state.sessionId}/stats`);
+  setStats(data);
+
+  if (data.currentBuzzPlayer) {
+    setBuzz({
+      playerName: data.currentBuzzPlayer.displayName,
+      proposal: data.currentBuzzProposal
+    });
+  }
+}
+
+byId('createSessionBtn').onclick = async () => {
+  const data = await api('/admin/api/sessions', 'POST');
+  state.sessionId = data.id;
+  state.sessionCode = data.code;
+  byId('sessionId').textContent = state.sessionId;
+  byId('sessionCode').textContent = state.sessionCode;
+  log(`Session créée: ${state.sessionId} (code ${state.sessionCode})`);
+
+  connectWs();
+  await refreshStats();
+};
+
+byId('startBtn').onclick = async () => {
+  await api(`/admin/api/sessions/${state.sessionId}/start`, 'POST');
+  log('Partie démarrée');
+};
+
+byId('stopBtn').onclick = async () => {
+  await api(`/admin/api/sessions/${state.sessionId}/stop`, 'POST');
+  log('Partie stoppée');
+};
+
+byId('launchRoundBtn').onclick = async () => {
+  await api(`/admin/api/sessions/${state.sessionId}/rounds`, 'POST', {
+    title: byId('roundTitle').value,
+    artist: byId('roundArtist').value,
+    year: Number(byId('roundYear').value),
+    yearBonus: Number(byId('roundYearBonus').value || 0)
+  });
+
+  log('Session musicale lancée');
+};
+
+byId('acceptBtn').onclick = async () => {
+  const data = await api(`/admin/api/sessions/${state.sessionId}/decision`, 'POST', { decision: 'accepted' });
+  setRanking(data.ranking);
+  setBuzz(null);
+  log(`Décision: accepted (delta ${data.scoreDelta})`);
+};
+
+byId('rejectBtn').onclick = async () => {
+  const data = await api(`/admin/api/sessions/${state.sessionId}/decision`, 'POST', { decision: 'rejected' });
+  setRanking(data.ranking);
+  setBuzz(null);
+  log(`Décision: rejected (delta ${data.scoreDelta})`);
+};
+
+byId('logoutBtn').onclick = async () => {
+  await api('/admin/logout', 'POST');
+  location.href = '/admin';
+};
+
+window.addEventListener('load', async () => {
+  const status = await api('/admin/auth-status');
+  if (!status.authenticated) {
+    location.href = '/admin';
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -3,50 +3,47 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Blind Test MVP</title>
+    <title>Blind Test Joueur</title>
     <style>
       body { font-family: system-ui, sans-serif; margin: 1rem; max-width: 800px; }
       .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
       button { padding: .7rem 1rem; border-radius: 6px; border: 1px solid #ccc; cursor: pointer; }
       .buzz { font-size: 1.5rem; width: 100%; padding: 2rem; }
-      input { padding: .6rem; margin-right: .4rem; }
+      input { padding: .6rem; margin-right: .4rem; margin-bottom: .4rem; }
       #log { font-family: monospace; font-size: .9rem; background: #f7f7f7; padding: .75rem; white-space: pre-wrap; }
       table { width: 100%; border-collapse: collapse; }
       td, th { border-bottom: 1px solid #eee; padding: .4rem; }
+      .status { font-weight: 700; }
     </style>
   </head>
   <body>
-    <h1>Blind Test MVP</h1>
+    <h1>Blind Test — Interface Joueur</h1>
+    <p><a href="/admin">Accéder à l'interface admin</a></p>
 
     <div class="card">
-      <h2>Connexion</h2>
-      <label>Session ID <input id="sessionId" /></label>
-      <button id="connectBtn">Connecter WS</button>
-    </div>
-
-    <div class="card">
-      <h2>Joueur</h2>
-      <input id="firstName" placeholder="Prénom" />
-      <input id="lastName" placeholder="Nom" />
+      <h2>Rejoindre la partie</h2>
+      <input id="sessionCode" placeholder="Code session" />
+      <input id="pseudo" placeholder="Pseudo unique" />
       <button id="joinBtn">Rejoindre</button>
-      <button class="buzz" id="buzzBtn">BUZZER</button>
-      <p>Player ID: <span id="playerId">-</span></p>
+      <p>Session ID: <strong id="sessionId">-</strong></p>
+      <p>Mon pseudo: <strong id="playerPseudo">-</strong></p>
+      <p>Mon player ID: <strong id="playerId">-</strong></p>
+      <p>Statut: <span class="status" id="sessionStatus">en attente</span></p>
+      <p id="winnerBox"></p>
     </div>
 
     <div class="card">
-      <h2>Admin</h2>
-      <input id="adminPassword" type="password" placeholder="Mot de passe admin" />
-      <button id="loginBtn">Login</button>
-      <button id="createSessionBtn">Créer session</button>
-      <button id="startBtn">Démarrer</button>
-      <button id="stopBtn">Stop</button>
-      <button id="acceptBtn">Valider +1</button>
-      <button id="rejectBtn">Refuser -1</button>
-      <p>Token: <span id="adminToken">-</span></p>
+      <h2>Réponse rapide (optionnel)</h2>
+      <input id="guessTitle" placeholder="Titre proposé" />
+      <input id="guessArtist" placeholder="Artiste proposé" />
+      <input id="guessYear" type="number" placeholder="Année proposée" />
+      <button class="buzz" id="buzzBtn">BUZZER</button>
+      <p id="decisionMessage"></p>
     </div>
 
     <div class="card">
       <h2>Classement</h2>
+      <p>Mon score: <strong id="myScore">0</strong></p>
       <table>
         <thead><tr><th>Joueur</th><th>Score</th></tr></thead>
         <tbody id="rankingBody"></tbody>

--- a/public/main.js
+++ b/public/main.js
@@ -1,7 +1,8 @@
 const state = {
   sessionId: '',
+  sessionCode: '',
   playerId: '',
-  adminToken: '',
+  pseudo: '',
   ws: null
 };
 
@@ -12,22 +13,45 @@ function log(message) {
   logEl.textContent = `${new Date().toLocaleTimeString()} - ${message}\n${logEl.textContent}`;
 }
 
+function setStatus(status) {
+  byId('sessionStatus').textContent = status;
+}
+
+function setWinner(winner) {
+  if (!winner) {
+    byId('winnerBox').textContent = '';
+    return;
+  }
+
+  byId('winnerBox').textContent = `🏆 Gagnant: ${winner.displayName} (${winner.score} pts)`;
+}
+
+function setDecisionMessage(payload) {
+  if (!payload) {
+    byId('decisionMessage').textContent = '';
+    return;
+  }
+
+  const action = payload.decision === 'accepted' ? 'validée' : 'refusée';
+  byId('decisionMessage').textContent = `Votre réponse a été ${action} (${payload.scoreDelta > 0 ? '+' : ''}${payload.scoreDelta}).`;
+}
+
 function setRanking(ranking) {
   const body = byId('rankingBody');
   body.innerHTML = ranking
-    .map((entry) => `<tr><td>${entry.firstName} ${entry.lastName}</td><td>${entry.score}</td></tr>`)
+    .map((entry) => `<tr><td>${entry.displayName}</td><td>${entry.score}</td></tr>`)
     .join('');
+
+  const me = ranking.find((entry) => entry.id === state.playerId);
+  if (me) {
+    byId('myScore').textContent = String(me.score);
+  }
 }
 
 async function api(path, method = 'GET', payload) {
-  const headers = { 'Content-Type': 'application/json' };
-  if (state.adminToken) {
-    headers.Authorization = `Bearer ${state.adminToken}`;
-  }
-
   const response = await fetch(path, {
     method,
-    headers,
+    headers: { 'Content-Type': 'application/json' },
     body: payload ? JSON.stringify(payload) : undefined
   });
 
@@ -39,70 +63,94 @@ async function api(path, method = 'GET', payload) {
   return data;
 }
 
-byId('connectBtn').onclick = () => {
-  state.sessionId = byId('sessionId').value;
+function connectWs() {
+  if (!state.sessionId || !state.playerId) {
+    return;
+  }
+
+  const wsUrl = new URL(location.origin.replace('http', 'ws'));
+  wsUrl.searchParams.set('sessionId', state.sessionId);
+  wsUrl.searchParams.set('playerId', state.playerId);
+
   state.ws?.close();
-  state.ws = new WebSocket(`${location.origin.replace('http', 'ws')}?sessionId=${state.sessionId}`);
+  state.ws = new WebSocket(wsUrl);
 
   state.ws.onopen = () => log('WebSocket connecté');
   state.ws.onmessage = (event) => {
     const { event: type, payload } = JSON.parse(event.data);
     log(`${type}: ${JSON.stringify(payload)}`);
+
+    if (type === 'session.started') {
+      setStatus('démarrée');
+    }
+
+    if (type === 'round.started') {
+      setDecisionMessage(null);
+    }
+
     if (type === 'ranking.updated') {
       setRanking(payload.ranking);
     }
+
+    if (type === 'buzz.decided' && payload.playerId === state.playerId) {
+      setDecisionMessage(payload);
+    }
+
+    if (type === 'session.stopped') {
+      setStatus('terminée');
+      setWinner(payload.winner);
+      if (payload.ranking) {
+        setRanking(payload.ranking);
+      }
+    }
   };
+
   state.ws.onclose = () => log('WebSocket fermé');
-};
-
-byId('loginBtn').onclick = async () => {
-  const data = await api('/admin/login', 'POST', { password: byId('adminPassword').value });
-  state.adminToken = data.token;
-  byId('adminToken').textContent = state.adminToken;
-  log('Admin connecté');
-};
-
-byId('createSessionBtn').onclick = async () => {
-  const data = await api('/sessions', 'POST');
-  state.sessionId = data.id;
-  byId('sessionId').value = state.sessionId;
-  log(`Session créée: ${data.id} (code ${data.code})`);
-};
-
-byId('startBtn').onclick = async () => {
-  await api(`/sessions/${state.sessionId}/start`, 'POST');
-  log('Session démarrée');
-};
-
-byId('stopBtn').onclick = async () => {
-  await api(`/sessions/${state.sessionId}/stop`, 'POST');
-  log('Session stoppée');
-};
+}
 
 byId('joinBtn').onclick = async () => {
-  const data = await api(`/sessions/${state.sessionId}/players`, 'POST', {
-    firstName: byId('firstName').value,
-    lastName: byId('lastName').value
-  });
+  try {
+    const data = await api('/sessions/join', 'POST', {
+      code: byId('sessionCode').value,
+      pseudo: byId('pseudo').value
+    });
 
-  state.playerId = data.playerId;
-  byId('playerId').textContent = state.playerId;
-  log(`Joueur inscrit: ${state.playerId}`);
+    state.sessionId = data.sessionId;
+    state.sessionCode = data.sessionCode;
+    state.playerId = data.playerId;
+    state.pseudo = data.pseudo;
+
+    byId('sessionId').textContent = state.sessionId;
+    byId('playerId').textContent = state.playerId;
+    byId('playerPseudo').textContent = state.pseudo;
+    setStatus(data.status === 'running' ? 'démarrée' : 'en attente');
+    setWinner(null);
+
+    log(`Joueur inscrit: ${state.pseudo} (${state.playerId})`);
+    connectWs();
+
+    const ranking = await api(`/sessions/${state.sessionId}/ranking`);
+    setRanking(ranking.ranking);
+    if (ranking.winner) {
+      setWinner(ranking.winner);
+    }
+  } catch (error) {
+    log(`Erreur join: ${error.message}`);
+  }
 };
 
 byId('buzzBtn').onclick = async () => {
-  await api(`/sessions/${state.sessionId}/buzz`, 'POST', { playerId: state.playerId });
-  log('Buzz envoyé');
-};
-
-byId('acceptBtn').onclick = async () => {
-  const data = await api(`/sessions/${state.sessionId}/decision`, 'POST', { decision: 'accepted' });
-  setRanking(data.ranking);
-  log('Décision: accepted');
-};
-
-byId('rejectBtn').onclick = async () => {
-  const data = await api(`/sessions/${state.sessionId}/decision`, 'POST', { decision: 'rejected' });
-  setRanking(data.ranking);
-  log('Décision: rejected');
+  try {
+    await api(`/sessions/${state.sessionId}/buzz`, 'POST', {
+      playerId: state.playerId,
+      proposal: {
+        title: byId('guessTitle').value,
+        artist: byId('guessArtist').value,
+        year: byId('guessYear').value
+      }
+    });
+    log('Buzz envoyé');
+  } catch (error) {
+    log(`Erreur buzz: ${error.message}`);
+  }
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,13 +1,18 @@
 import crypto from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import express from 'express';
 import { WebSocketServer } from 'ws';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 const port = process.env.PORT || 3000;
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin123';
 
 app.use(express.json());
-app.use(express.static('public'));
+app.use(express.static(path.join(__dirname, '../public')));
 
 const sessions = new Map();
 const sessionSockets = new Map();
@@ -19,8 +24,27 @@ function code() {
   return Math.random().toString(36).slice(2, 8).toUpperCase();
 }
 
-function ranking(session) {
-  return [...session.players].sort((a, b) => b.score - a.score || a.joinedAt - b.joinedAt);
+function normalizePseudo(value = '') {
+  return value.trim().toLowerCase();
+}
+
+function displayName(player) {
+  if (player.pseudo) {
+    return player.pseudo;
+  }
+
+  return `${player.firstName ?? ''} ${player.lastName ?? ''}`.trim();
+}
+
+function serializeRanking(session) {
+  return [...session.players]
+    .sort((a, b) => b.score - a.score || a.joinedAt - b.joinedAt)
+    .map((player) => ({
+      id: player.id,
+      pseudo: player.pseudo,
+      displayName: displayName(player),
+      score: player.score
+    }));
 }
 
 function socketGroup(sessionId) {
@@ -40,8 +64,31 @@ function broadcast(sessionId, event, payload = {}) {
   }
 }
 
+function parseCookies(req) {
+  const cookieHeader = req.headers.cookie ?? '';
+  return cookieHeader
+    .split(';')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .reduce((acc, entry) => {
+      const [name, ...rest] = entry.split('=');
+      acc[name] = decodeURIComponent(rest.join('='));
+      return acc;
+    }, {});
+}
+
+function getAdminToken(req) {
+  const authHeader = req.headers.authorization?.replace('Bearer ', '');
+  if (authHeader) {
+    return authHeader;
+  }
+
+  const cookies = parseCookies(req);
+  return cookies.admin_token;
+}
+
 function mustBeAdmin(req, res, next) {
-  const token = req.headers.authorization?.replace('Bearer ', '');
+  const token = getAdminToken(req);
   if (!token || !adminTokens.has(token)) {
     return res.status(401).json({ error: 'unauthorized' });
   }
@@ -59,6 +106,24 @@ function getSession(req, res) {
   return session;
 }
 
+function connectedPlayersPayload(session) {
+  return {
+    connectedPlayers: session.connectedPlayerIds.size,
+    registeredPlayers: session.players.length
+  };
+}
+
+function winnerFromSession(session) {
+  const rank = serializeRanking(session);
+  return rank.length > 0 ? rank[0] : null;
+}
+
+app.get('/admin', (req, res) => {
+  const token = getAdminToken(req);
+  const view = token && adminTokens.has(token) ? 'admin.html' : 'admin-login.html';
+  res.sendFile(path.join(__dirname, 'views', view));
+});
+
 app.post('/admin/login', (req, res) => {
   const { password } = req.body ?? {};
   if (password !== ADMIN_PASSWORD) {
@@ -67,10 +132,29 @@ app.post('/admin/login', (req, res) => {
 
   const token = uuid();
   adminTokens.add(token);
-  res.json({ token });
+
+  const oneDayInSeconds = 24 * 60 * 60;
+  res.setHeader(
+    'Set-Cookie',
+    `admin_token=${encodeURIComponent(token)}; HttpOnly; SameSite=Strict; Path=/; Max-Age=${oneDayInSeconds}`
+  );
+
+  res.json({ ok: true });
 });
 
-app.post('/sessions', mustBeAdmin, (_req, res) => {
+app.post('/admin/logout', mustBeAdmin, (req, res) => {
+  const token = getAdminToken(req);
+  adminTokens.delete(token);
+  res.setHeader('Set-Cookie', 'admin_token=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0');
+  res.json({ ok: true });
+});
+
+app.get('/admin/auth-status', (req, res) => {
+  const token = getAdminToken(req);
+  res.json({ authenticated: Boolean(token && adminTokens.has(token)) });
+});
+
+app.post('/admin/api/sessions', mustBeAdmin, (_req, res) => {
   const id = uuid();
   const newSession = {
     id,
@@ -78,14 +162,22 @@ app.post('/sessions', mustBeAdmin, (_req, res) => {
     status: 'waiting',
     buzzLocked: false,
     currentBuzzPlayerId: null,
+    currentBuzzProposal: null,
+    currentRound: null,
+    connectedPlayerIds: new Set(),
     players: []
   };
 
   sessions.set(id, newSession);
-  res.status(201).json(newSession);
+
+  res.status(201).json({
+    id: newSession.id,
+    code: newSession.code,
+    status: newSession.status
+  });
 });
 
-app.post('/sessions/:id/start', mustBeAdmin, (req, res) => {
+app.post('/admin/api/sessions/:id/start', mustBeAdmin, (req, res) => {
   const session = getSession(req, res);
   if (!session) return;
 
@@ -94,42 +186,121 @@ app.post('/sessions/:id/start', mustBeAdmin, (req, res) => {
   res.json({ ok: true, status: session.status });
 });
 
-app.post('/sessions/:id/stop', mustBeAdmin, (req, res) => {
+app.post('/admin/api/sessions/:id/stop', mustBeAdmin, (req, res) => {
   const session = getSession(req, res);
   if (!session) return;
 
   session.status = 'stopped';
   session.buzzLocked = true;
-  broadcast(session.id, 'session.stopped', { sessionId: session.id });
-  res.json({ ok: true, status: session.status });
+
+  const finalRanking = serializeRanking(session);
+  const winner = finalRanking.length > 0 ? finalRanking[0] : null;
+
+  broadcast(session.id, 'session.stopped', {
+    sessionId: session.id,
+    winner,
+    ranking: finalRanking
+  });
+
+  res.json({ ok: true, status: session.status, winner });
 });
 
-app.post('/sessions/:id/players', (req, res) => {
+app.post('/admin/api/sessions/:id/rounds', mustBeAdmin, (req, res) => {
   const session = getSession(req, res);
   if (!session) return;
 
-  const { firstName, lastName } = req.body ?? {};
-  if (!firstName || !lastName) {
-    return res.status(400).json({ error: 'missing_name' });
+  const { title, artist, year, yearBonus = 0 } = req.body ?? {};
+  if (!title || !artist || !year) {
+    return res.status(400).json({ error: 'missing_round_data' });
+  }
+
+  session.currentRound = {
+    title,
+    artist,
+    year,
+    yearBonus
+  };
+
+  session.buzzLocked = false;
+  session.currentBuzzPlayerId = null;
+  session.currentBuzzProposal = null;
+
+  broadcast(session.id, 'round.started', {
+    hint: 'Nouveau morceau en cours',
+    yearBonus
+  });
+
+  res.json({ ok: true, currentRound: session.currentRound });
+});
+
+app.get('/admin/api/sessions/:id/stats', mustBeAdmin, (req, res) => {
+  const session = getSession(req, res);
+  if (!session) return;
+
+  const currentBuzzPlayer = session.players.find((entry) => entry.id === session.currentBuzzPlayerId) ?? null;
+
+  res.json({
+    status: session.status,
+    ...connectedPlayersPayload(session),
+    currentBuzzPlayer: currentBuzzPlayer
+      ? {
+          id: currentBuzzPlayer.id,
+          pseudo: currentBuzzPlayer.pseudo,
+          displayName: displayName(currentBuzzPlayer),
+          score: currentBuzzPlayer.score
+        }
+      : null,
+    currentBuzzProposal: session.currentBuzzProposal
+  });
+});
+
+app.post('/sessions/join', (req, res) => {
+  const { code: sessionCode, pseudo } = req.body ?? {};
+  if (!sessionCode || !pseudo) {
+    return res.status(400).json({ error: 'missing_join_data' });
+  }
+
+  const normalizedCode = String(sessionCode).trim().toUpperCase();
+  const session = [...sessions.values()].find((entry) => entry.code === normalizedCode);
+
+  if (!session) {
+    return res.status(404).json({ error: 'session_not_found' });
+  }
+
+  if (session.status === 'stopped') {
+    return res.status(409).json({ error: 'session_stopped' });
+  }
+
+  const normalizedPseudo = normalizePseudo(pseudo);
+  const pseudoAlreadyUsed = session.players.some((entry) => normalizePseudo(entry.pseudo) === normalizedPseudo);
+  if (pseudoAlreadyUsed) {
+    return res.status(409).json({ error: 'pseudo_already_used' });
   }
 
   const player = {
     id: uuid(),
-    firstName,
-    lastName,
+    pseudo: String(pseudo).trim(),
     joinedAt: Date.now(),
     score: 0
   };
 
   session.players.push(player);
-  res.status(201).json({ playerId: player.id, sessionId: session.id });
+  broadcast(session.id, 'players.connected.updated', connectedPlayersPayload(session));
+
+  res.status(201).json({
+    sessionId: session.id,
+    sessionCode: session.code,
+    playerId: player.id,
+    pseudo: player.pseudo,
+    status: session.status
+  });
 });
 
 app.post('/sessions/:id/buzz', (req, res) => {
   const session = getSession(req, res);
   if (!session) return;
 
-  const { playerId } = req.body ?? {};
+  const { playerId, proposal } = req.body ?? {};
   const player = session.players.find((entry) => entry.id === playerId);
   if (!player) {
     return res.status(404).json({ error: 'player_not_found' });
@@ -145,16 +316,18 @@ app.post('/sessions/:id/buzz', (req, res) => {
 
   session.buzzLocked = true;
   session.currentBuzzPlayerId = player.id;
+  session.currentBuzzProposal = proposal ?? null;
 
   broadcast(session.id, 'buzz.locked', {
     playerId: player.id,
-    playerName: `${player.firstName} ${player.lastName}`
+    playerName: displayName(player),
+    proposal: session.currentBuzzProposal
   });
 
   res.json({ accepted: true, playerId: player.id });
 });
 
-app.post('/sessions/:id/decision', mustBeAdmin, (req, res) => {
+app.post('/admin/api/sessions/:id/decision', mustBeAdmin, (req, res) => {
   const session = getSession(req, res);
   if (!session) return;
 
@@ -168,28 +341,44 @@ app.post('/sessions/:id/decision', mustBeAdmin, (req, res) => {
     return res.status(409).json({ error: 'no_current_buzz' });
   }
 
-  player.score += decision === 'accepted' ? 1 : -1;
-  const rank = ranking(session);
+  let scoreDelta = decision === 'accepted' ? 1 : -1;
+
+  if (decision === 'accepted' && session.currentRound && session.currentBuzzProposal?.year) {
+    const gap = Math.abs(Number(session.currentRound.year) - Number(session.currentBuzzProposal.year));
+    if (Number.isFinite(gap) && gap <= 1) {
+      scoreDelta += Number(session.currentRound.yearBonus || 0);
+    }
+  }
+
+  player.score += scoreDelta;
+  const rank = serializeRanking(session);
 
   broadcast(session.id, 'buzz.decided', {
     playerId: player.id,
+    playerName: displayName(player),
     decision,
-    score: player.score
+    score: player.score,
+    scoreDelta
   });
 
   broadcast(session.id, 'ranking.updated', { ranking: rank });
 
   session.buzzLocked = false;
   session.currentBuzzPlayerId = null;
+  session.currentBuzzProposal = null;
 
-  res.json({ ok: true, ranking: rank });
+  res.json({ ok: true, ranking: rank, scoreDelta });
 });
 
 app.get('/sessions/:id/ranking', (req, res) => {
   const session = getSession(req, res);
   if (!session) return;
 
-  res.json({ ranking: ranking(session), status: session.status });
+  res.json({
+    ranking: serializeRanking(session),
+    status: session.status,
+    winner: session.status === 'stopped' ? winnerFromSession(session) : null
+  });
 });
 
 const server = app.listen(port, () => {
@@ -201,15 +390,28 @@ const wss = new WebSocketServer({ server });
 wss.on('connection', (ws, req) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
   const sessionId = url.searchParams.get('sessionId');
+  const playerId = url.searchParams.get('playerId');
+
   if (!sessionId || !sessions.has(sessionId)) {
     ws.close(1008, 'missing_or_invalid_session');
     return;
   }
 
+  const session = sessions.get(sessionId);
   const peers = socketGroup(sessionId);
   peers.add(ws);
 
+  if (playerId && session.players.some((entry) => entry.id === playerId)) {
+    session.connectedPlayerIds.add(playerId);
+    broadcast(session.id, 'players.connected.updated', connectedPlayersPayload(session));
+  }
+
   ws.on('close', () => {
     peers.delete(ws);
+
+    if (playerId && session.connectedPlayerIds.has(playerId)) {
+      session.connectedPlayerIds.delete(playerId);
+      broadcast(session.id, 'players.connected.updated', connectedPlayersPayload(session));
+    }
   });
 });

--- a/server/views/admin-login.html
+++ b/server/views/admin-login.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Login</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 520px; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; }
+      input { width: 100%; padding: .7rem; margin: .5rem 0; }
+      button { padding: .7rem 1rem; border-radius: 6px; border: 1px solid #ccc; cursor: pointer; }
+      #error { color: #b00020; }
+    </style>
+  </head>
+  <body>
+    <h1>Interface Admin</h1>
+    <div class="card">
+      <p>Cette interface est protégée par mot de passe serveur.</p>
+      <input id="password" type="password" placeholder="Mot de passe admin" />
+      <button id="loginBtn">Se connecter</button>
+      <p id="error"></p>
+    </div>
+
+    <script>
+      document.getElementById('loginBtn').onclick = async () => {
+        const password = document.getElementById('password').value;
+        const errorEl = document.getElementById('error');
+        errorEl.textContent = '';
+
+        const response = await fetch('/admin/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ password })
+        });
+
+        if (!response.ok) {
+          errorEl.textContent = 'Mot de passe invalide';
+          return;
+        }
+
+        location.href = '/admin';
+      };
+    </script>
+  </body>
+</html>

--- a/server/views/admin.html
+++ b/server/views/admin.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blind Test Admin</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 1rem; max-width: 900px; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+      button { padding: .6rem 1rem; border-radius: 6px; border: 1px solid #ccc; cursor: pointer; margin-right: .4rem; }
+      input { padding: .6rem; margin-right: .4rem; margin-bottom: .4rem; }
+      #log { font-family: monospace; font-size: .9rem; background: #f7f7f7; padding: .75rem; white-space: pre-wrap; }
+      table { width: 100%; border-collapse: collapse; }
+      td, th { border-bottom: 1px solid #eee; padding: .4rem; }
+      .stats { display: flex; gap: 1rem; }
+      .pill { background: #f2f2f2; border-radius: 999px; padding: .2rem .7rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Back-office Admin</h1>
+
+    <div class="card">
+      <h2>Gestion partie</h2>
+      <button id="createSessionBtn">Nouvelle partie</button>
+      <button id="startBtn">Lancer la partie</button>
+      <button id="stopBtn">Stop partie</button>
+      <button id="logoutBtn">Se déconnecter</button>
+      <p>Session ID: <strong id="sessionId">-</strong></p>
+      <p>Code session: <strong id="sessionCode">-</strong></p>
+      <div class="stats">
+        <span class="pill">Connectés: <strong id="connectedPlayers">0</strong></span>
+        <span class="pill">Inscrits: <strong id="registeredPlayers">0</strong></span>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Lancer une session musicale</h2>
+      <input id="roundTitle" placeholder="Titre" />
+      <input id="roundArtist" placeholder="Artiste" />
+      <input id="roundYear" type="number" placeholder="Année" />
+      <input id="roundYearBonus" type="number" placeholder="Bonus année" value="1" />
+      <button id="launchRoundBtn">Lancer le morceau</button>
+    </div>
+
+    <div class="card">
+      <h2>Premier buzz</h2>
+      <p>Joueur: <strong id="buzzPlayer">-</strong></p>
+      <p>Proposition: <span id="buzzProposal">-</span></p>
+      <button id="acceptBtn">Valider la réponse</button>
+      <button id="rejectBtn">Refuser la réponse</button>
+    </div>
+
+    <div class="card">
+      <h2>Classement</h2>
+      <table>
+        <thead><tr><th>Joueur</th><th>Score</th></tr></thead>
+        <tbody id="rankingBody"></tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h2>Logs</h2>
+      <div id="log"></div>
+    </div>
+
+    <script type="module" src="/admin.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Introduce a simple admin back-office with server-side authentication and dedicated admin UI to manage sessions and rounds. 
- Improve player onboarding with session codes and unique pseudos and provide richer real-time UI updates for both admin and players. 
- Add round/score logic including year-based bonus and better WebSocket payloads for connected players, buzz proposals and final winner announcements.

### Description
- Implement server-side admin auth using a cookie (`admin_token`) with endpoints `POST /admin/login`, `POST /admin/logout`, and `GET /admin/auth-status`, and require `mustBeAdmin` for admin APIs under `/admin/api/*`.
- Add admin views (`server/views/admin.html`, `server/views/admin-login.html`) and client admin script (`public/admin.js`) to create/start/stop sessions, launch rounds, accept/reject buzzes and display live stats/ranking.
- Revamp player flow in `public/index.html` and `public/main.js` to join by session code with a unique `pseudo`, receive status/winner/decision messages, send buzz proposals, and open WebSocket with `sessionId` and `playerId` query params.
- Update server logic in `server/index.js` to serve static files via `path.join`, track sessions and connected players, add `serializeRanking`/`displayName` helpers, implement `POST /admin/api/sessions`, `POST /admin/api/sessions/:id/start`, `POST /admin/api/sessions/:id/stop`, `POST /admin/api/sessions/:id/rounds`, `GET /admin/api/sessions/:id/stats`, `POST /sessions/join`, and admin decision endpoint `POST /admin/api/sessions/:id/decision` with scoring delta that includes a `yearBonus` when the guessed year is within 1 year.
- Enhance WebSocket broadcasts to include events `round.started`, `players.connected.updated`, `buzz.locked` with `proposal`, `buzz.decided` with `scoreDelta`, `ranking.updated`, and `session.stopped` including the final winner and ranking.
- Update `README.md` to document the new admin and player endpoints, WebSocket query params, and feature summary.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ff1cea38832ab39ce0567c8eb6ee)