### PR TITLE
Ajout d'un script PowerShell interactif de déploiement Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,40 @@ Connexion sur `ws://host:port/?sessionId=<SESSION_ID>&playerId=<PLAYER_ID>`.
 - Le client joueur mémorise aussi sa session active pour reprise sur la vue Joueur et pour quitter proprement la partie.
 - Le client admin mémorise la session active pour reprise après F5/retour page.
 - Auth admin gérée côté serveur via cookie HTTP-only après login.
+
+## Déploiement Azure (PowerShell)
+
+Un script interactif et paramétrable est disponible : `scripts/deploy-azure.ps1`.
+
+### Prérequis
+
+- Azure CLI (`az`)
+- PowerShell 7+
+- Node.js / npm
+
+### Exemple (interactif)
+
+```powershell
+pwsh -File ./scripts/deploy-azure.ps1
+```
+
+### Exemple (paramétré)
+
+```powershell
+pwsh -File ./scripts/deploy-azure.ps1 \
+  -SubscriptionId "<subscription-id>" \
+  -ResourceGroup "rg-blindtest-prod" \
+  -Location "westeurope" \
+  -AppName "blindtest-prod-12345" \
+  -PlanName "asp-blindtest-prod" \
+  -Sku "B1" \
+  -Runtime "NODE:20-lts" \
+  -AdminPassword "<mot-de-passe-admin>"
+```
+
+Le script :
+- crée/met à jour le Resource Group,
+- crée/met à jour l'App Service Plan Linux,
+- crée/met à jour la Web App,
+- configure les variables d'environnement,
+- déploie l'application sur Azure App Service.

--- a/scripts/deploy-azure.ps1
+++ b/scripts/deploy-azure.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ResourceGroup,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Location,
+
+    [Parameter(Mandatory = $false)]
+    [string]$AppName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$PlanName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Sku = "B1",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Runtime = "NODE:20-lts",
+
+    [Parameter(Mandatory = $false)]
+    [string]$AdminPassword,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipBuild,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+function Read-IfEmpty {
+    param(
+        [string]$CurrentValue,
+        [string]$Label,
+        [string]$DefaultValue = ""
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return $CurrentValue
+    }
+
+    if ([string]::IsNullOrWhiteSpace($DefaultValue)) {
+        return (Read-Host $Label)
+    }
+
+    $value = Read-Host "$Label [$DefaultValue]"
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $DefaultValue
+    }
+
+    return $value
+}
+
+function Confirm-Action {
+    param([string]$Message)
+
+    $answer = Read-Host "$Message (y/N)"
+    return $answer -match '^(y|yes|o|oui)$'
+}
+
+function Require-Command {
+    param([string]$Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "La commande '$Name' est introuvable. Installez-la puis relancez le script."
+    }
+}
+
+Write-Host "=== Déploiement Azure Web App (Node.js) ===" -ForegroundColor Cyan
+
+Require-Command -Name "az"
+Require-Command -Name "git"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+$SubscriptionId = Read-IfEmpty -CurrentValue $SubscriptionId -Label "Subscription ID Azure (laisser vide pour conserver le contexte actuel)"
+$ResourceGroup = Read-IfEmpty -CurrentValue $ResourceGroup -Label "Nom du Resource Group" -DefaultValue "rg-blindtest"
+$Location = Read-IfEmpty -CurrentValue $Location -Label "Région Azure" -DefaultValue "westeurope"
+$AppName = Read-IfEmpty -CurrentValue $AppName -Label "Nom global unique de la Web App"
+$PlanName = Read-IfEmpty -CurrentValue $PlanName -Label "Nom du App Service Plan" -DefaultValue "$($ResourceGroup)-plan"
+$Sku = Read-IfEmpty -CurrentValue $Sku -Label "SKU App Service Plan" -DefaultValue "B1"
+$Runtime = Read-IfEmpty -CurrentValue $Runtime -Label "Runtime Stack (ex: NODE:20-lts)" -DefaultValue "NODE:20-lts"
+$AdminPassword = Read-IfEmpty -CurrentValue $AdminPassword -Label "Mot de passe admin applicatif" -DefaultValue "admin123"
+
+if (-not (Confirm-Action -Message "Continuer avec ces paramètres")) {
+    throw "Déploiement annulé par l'utilisateur."
+}
+
+Write-Host "\nRécapitulatif:" -ForegroundColor Yellow
+Write-Host "- Resource Group : $ResourceGroup"
+Write-Host "- Location       : $Location"
+Write-Host "- App Name       : $AppName"
+Write-Host "- Plan Name      : $PlanName"
+Write-Host "- SKU            : $Sku"
+Write-Host "- Runtime        : $Runtime"
+
+if ($WhatIf) {
+    Write-Host "\nMode WhatIf activé : aucune commande Azure ne sera exécutée." -ForegroundColor Yellow
+    exit 0
+}
+
+Write-Host "\nConnexion Azure..." -ForegroundColor Cyan
+az account show 1>$null 2>$null
+if ($LASTEXITCODE -ne 0) {
+    az login | Out-Null
+}
+
+if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    az account set --subscription $SubscriptionId
+}
+
+Write-Host "Création / mise à jour du Resource Group..." -ForegroundColor Cyan
+az group create --name $ResourceGroup --location $Location | Out-Null
+
+Write-Host "Création / mise à jour du App Service Plan..." -ForegroundColor Cyan
+az appservice plan create --name $PlanName --resource-group $ResourceGroup --location $Location --sku $Sku --is-linux | Out-Null
+
+Write-Host "Création / mise à jour de la Web App..." -ForegroundColor Cyan
+az webapp create --name $AppName --resource-group $ResourceGroup --plan $PlanName --runtime $Runtime | Out-Null
+
+Write-Host "Configuration des variables d'environnement..." -ForegroundColor Cyan
+az webapp config appsettings set --name $AppName --resource-group $ResourceGroup --settings "WEBSITE_NODE_DEFAULT_VERSION=~20" "SCM_DO_BUILD_DURING_DEPLOYMENT=true" "ADMIN_PASSWORD=$AdminPassword" | Out-Null
+
+if (-not $SkipBuild) {
+    Write-Host "Installation des dépendances Node.js..." -ForegroundColor Cyan
+    npm ci
+}
+
+Write-Host "Déploiement du code source (zip deploy via az webapp up)..." -ForegroundColor Cyan
+az webapp up --name $AppName --resource-group $ResourceGroup --plan $PlanName --location $Location --runtime $Runtime --sku $Sku | Out-Null
+
+$url = "https://$AppName.azurewebsites.net"
+Write-Host "\n✅ Déploiement terminé." -ForegroundColor Green
+Write-Host "URL: $url" -ForegroundColor Green


### PR DESCRIPTION
### Motivation

- Fournir un script réutilisable et paramétrable pour déployer l'application Node.js sur Azure App Service afin de simplifier les mises en production.
- Permettre à la fois un mode interactif (prompts avec valeurs par défaut) et un mode paramétré pour l'automatisation des déploiements.

### Description

- Ajout du fichier `scripts/deploy-azure.ps1` qui accepte des paramètres (`-SubscriptionId`, `-ResourceGroup`, `-Location`, `-AppName`, `-PlanName`, `-Sku`, `-Runtime`, `-AdminPassword`, `-SkipBuild`, `-WhatIf`) et propose des invites interactives lorsque les paramètres sont omis.
- Le script vérifie la présence des outils requis via `Require-Command` (`az`, `git`), gère la connexion Azure, crée/met à jour le `Resource Group`, l'`App Service Plan` et la `Web App`, configure les app settings et déploie le code avec `az webapp up`.
- Ajout d'options opérationnelles : `-SkipBuild` pour sauter `npm ci` local et `-WhatIf` pour un dry-run sans exécution des commandes Azure.
- Mise à jour de `README.md` pour documenter le script, ses prérequis (`az`, PowerShell 7+, `npm`) et fournir des exemples d'exécution interactifs et paramétrés.

### Testing

- Tentative d'analyse syntaxique PowerShell via `pwsh -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile('scripts/deploy-azure.ps1',[ref]$null,[ref]$null); Write-Host 'PowerShell parse OK'"` a échoué car `pwsh` n'est pas installé dans l'environnement d'exécution automatisé.
- Aucun autre test automatisé de déploiement (`az`, `npm ci`) n'a été exécuté dans ce contexte CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58d532474832a998e09891bc4e14c)