### PR TITLE
Add LLM-based automatic buzz validation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Les specifications ecran par ecran sont disponibles dans [docs](c:/Projets/Quiz/
 
 - `PORT` (défaut `3000`)
 - `ADMIN_PASSWORD` (défaut `admin123`)
+- `OPENAI_API_KEY` (active la validation auto par IA)
+- `ANSWER_VALIDATION_MODEL` (défaut `gpt-4.1-mini`)
+- `ANSWER_VALIDATION_TIMEOUT_MS` (défaut `8000`)
 
 ## API disponible
 
@@ -74,6 +77,7 @@ Les specifications ecran par ecran sont disponibles dans [docs](c:/Projets/Quiz/
 - `POST /admin/api/sessions/:id/playlist/load`
 - `GET /admin/api/sessions/:id/stats`
 - `POST /admin/api/sessions/:id/decision`
+- `POST /admin/api/sessions/:id/decision/ai` (valide automatiquement via LLM en JSON strict)
 
 ### Joueur
 
@@ -83,7 +87,7 @@ Les specifications ecran par ecran sont disponibles dans [docs](c:/Projets/Quiz/
 - `GET /sessions/:id/players/:playerId`
 - `PUT /sessions/:id/players/:playerId/profile`
 - `DELETE /sessions/:id/players/:playerId`
-- `POST /sessions/:id/buzz`
+- `POST /sessions/:id/buzz` (accepte `proposal` structuré ou texte libre)
 - `GET /sessions/:id/ranking`
 
 ### WebSocket

--- a/server/README.md
+++ b/server/README.md
@@ -64,6 +64,9 @@ Le point d'entree applicatif est [index.js](c:/Projets/Quiz/hello-world/server/i
   - gestion des groupes de sockets,
   - diffusion des evenements,
   - synchronisation initiale a la connexion.
+- [services/llm-answer-validator.js](c:/Projets/Quiz/hello-world/server/services/llm-answer-validator.js)
+  - validation automatique d'une reponse en texte libre via LLM,
+  - retour JSON strict (verdict + confiance + checks) exploitable cote serveur.
 
 ### Utilitaires
 
@@ -118,6 +121,9 @@ node --check server/index.js
 
 - `PORT` : port HTTP du serveur, par defaut `3000`
 - `ADMIN_PASSWORD` : mot de passe admin, par defaut `admin123`
+- `OPENAI_API_KEY` : cle API pour activer la validation IA des buzz
+- `ANSWER_VALIDATION_MODEL` : modele OpenAI utilise (defaut `gpt-4.1-mini`)
+- `ANSWER_VALIDATION_TIMEOUT_MS` : timeout HTTP de validation IA (defaut `8000`)
 
 ## Contrats a preserver
 

--- a/server/config.js
+++ b/server/config.js
@@ -16,3 +16,7 @@ export const DEFAULT_PORT = Number(process.env.PORT) || 3000;
 export const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin123';
 export const AVATAR_MAX_BASE64 = 300 * 1024;
 export const PLAYLIST_UPLOAD_MAX_TEXT = 500 * 1024;
+
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+export const ANSWER_VALIDATION_MODEL = process.env.ANSWER_VALIDATION_MODEL || 'gpt-4.1-mini';
+export const ANSWER_VALIDATION_TIMEOUT_MS = Number(process.env.ANSWER_VALIDATION_TIMEOUT_MS) || 8000;

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,14 @@
 import express from 'express';
 import { WebSocketServer } from 'ws';
-import { ADMIN_PASSWORD, DEFAULT_PORT, PUBLIC_DIR, VIEWS_DIR } from './config.js';
+import {
+  ADMIN_PASSWORD,
+  ANSWER_VALIDATION_MODEL,
+  ANSWER_VALIDATION_TIMEOUT_MS,
+  DEFAULT_PORT,
+  OPENAI_API_KEY,
+  PUBLIC_DIR,
+  VIEWS_DIR
+} from './config.js';
 import { createAdminAuthRoutes } from './routes/admin-auth-routes.js';
 import { createAdminPlaylistRoutes } from './routes/admin-playlist-routes.js';
 import { createAdminSessionRoutes } from './routes/admin-session-routes.js';
@@ -9,6 +17,7 @@ import { createPlayerRoutes } from './routes/player-routes.js';
 import { createPublicSessionRoutes } from './routes/public-session-routes.js';
 import { createAdminAuthService } from './services/admin-auth.js';
 import { createGameService } from './services/game.js';
+import { createLlmAnswerValidatorService } from './services/llm-answer-validator.js';
 import { createPersistenceService } from './services/persistence.js';
 import { createWebsocketService } from './services/websocket.js';
 import {
@@ -33,6 +42,12 @@ const websocketService = createWebsocketService({
   buildSessionSnapshot,
   connectedPlayersPayload
 });
+const llmAnswerValidatorService = createLlmAnswerValidatorService({
+  apiKey: OPENAI_API_KEY,
+  model: ANSWER_VALIDATION_MODEL,
+  timeoutMs: ANSWER_VALIDATION_TIMEOUT_MS
+});
+
 const gameService = createGameService({
   state,
   persistSessionsToDisk: persistenceService.persistSessionsToDisk,
@@ -51,7 +66,13 @@ app.use(express.static(PUBLIC_DIR));
 app.use(createPageRoutes({ publicDir: PUBLIC_DIR, viewsDir: VIEWS_DIR, authService }));
 app.use(createAdminAuthRoutes({ authService, adminPassword: ADMIN_PASSWORD }));
 app.use(createAdminPlaylistRoutes({ authService, persistenceService, state }));
-app.use(createAdminSessionRoutes({ authService, gameService, persistenceService, state }));
+app.use(createAdminSessionRoutes({
+  authService,
+  gameService,
+  llmAnswerValidatorService,
+  persistenceService,
+  state
+}));
 app.use(createPublicSessionRoutes({ state }));
 app.use(createPlayerRoutes({
   broadcast: websocketService.broadcast,

--- a/server/routes/admin-session-routes.js
+++ b/server/routes/admin-session-routes.js
@@ -8,7 +8,8 @@ export function createAdminSessionRoutes({
 	authService,
 	gameService,
 	persistenceService,
-	state
+	state,
+	llmAnswerValidatorService
 }) {
 	const router = express.Router();
 
@@ -243,6 +244,53 @@ export function createAdminSessionRoutes({
 			currentPlaylistLibraryId: session.currentPlaylistLibraryId,
 			playlist: session.playlist,
 			currentTrackIndex: session.currentTrackIndex
+		});
+	});
+
+
+	router.post('/admin/api/sessions/:id/decision/ai', async (req, res) => {
+		const session = getSession(req, res, state.sessions);
+		if (!session) return;
+
+		if (!llmAnswerValidatorService?.enabled) {
+			return res.status(503).json({ error: 'llm_validation_not_configured' });
+		}
+
+		const buzzPlayer = session.players.find((entry) => entry.id === session.currentBuzzPlayerId);
+		if (!buzzPlayer || !session.currentRound) {
+			return res.status(409).json({ error: 'no_current_buzz' });
+		}
+
+		const answerText = String(req.body?.answerText ?? session.currentBuzzProposal?.text ?? '').trim();
+		if (!answerText) {
+			return res.status(400).json({ error: 'missing_answer_text' });
+		}
+
+		let aiValidation;
+		try {
+			aiValidation = await llmAnswerValidatorService.validateAnswer({
+				currentRound: session.currentRound,
+				playerAnswerText: answerText
+			});
+		} catch (error) {
+			return res.status(503).json({
+				error: error.code || 'llm_validation_failed',
+				details: error.message
+			});
+		}
+
+		const result = gameService.applyDecision(session, aiValidation.verdict);
+		if (!result) {
+			return res.status(409).json({ error: 'no_current_buzz' });
+		}
+
+		res.json({
+			ok: true,
+			decision: aiValidation.verdict,
+			aiValidation,
+			ranking: result.ranking,
+			scoreDelta: result.scoreDelta,
+			playerId: buzzPlayer.id
 		});
 	});
 

--- a/server/routes/player-routes.js
+++ b/server/routes/player-routes.js
@@ -125,6 +125,20 @@ export function createPlayerRoutes({ broadcast, gameService, persistenceService,
 		if (!session) return;
 
 		const { playerId, proposal } = req.body ?? {};
+		const normalizedProposal = typeof proposal === 'string'
+			? { text: proposal.trim() }
+			: {
+				text: String(proposal?.text ?? '').trim() || undefined,
+				title: String(proposal?.title ?? '').trim() || undefined,
+				artist: String(proposal?.artist ?? '').trim() || undefined,
+				year: proposal?.year !== undefined && proposal?.year !== null
+					? Number(proposal.year)
+					: undefined
+			};
+		if (!normalizedProposal.text && !normalizedProposal.title && !normalizedProposal.artist && !Number.isFinite(normalizedProposal.year)) {
+			return res.status(400).json({ error: 'missing_proposal' });
+		}
+
 		const player = session.players.find((entry) => entry.id === playerId);
 		if (!player) {
 			return res.status(404).json({ error: 'player_not_found' });
@@ -138,7 +152,7 @@ export function createPlayerRoutes({ broadcast, gameService, persistenceService,
 			return res.status(409).json({ error: 'buzz_locked', currentBuzzPlayerId: session.currentBuzzPlayerId });
 		}
 
-		const result = gameService.lockBuzz(session, player, proposal);
+		const result = gameService.lockBuzz(session, player, normalizedProposal);
 		res.json(result);
 	});
 

--- a/server/services/llm-answer-validator.js
+++ b/server/services/llm-answer-validator.js
@@ -1,0 +1,133 @@
+const JSON_SCHEMA = {
+	name: 'blind_test_answer_validation',
+	strict: true,
+	schema: {
+		type: 'object',
+		additionalProperties: false,
+		required: ['verdict', 'confidence', 'rationale', 'normalizedAnswer', 'checks'],
+		properties: {
+			verdict: { type: 'string', enum: ['accepted', 'rejected'] },
+			confidence: { type: 'number', minimum: 0, maximum: 1 },
+			rationale: { type: 'string', minLength: 1, maxLength: 300 },
+			normalizedAnswer: {
+				type: 'object',
+				additionalProperties: false,
+				required: ['title', 'artist', 'year'],
+				properties: {
+					title: { type: ['string', 'null'] },
+					artist: { type: ['string', 'null'] },
+					year: { type: ['number', 'null'] }
+				}
+			},
+			checks: {
+				type: 'object',
+				additionalProperties: false,
+				required: ['title', 'artist', 'year'],
+				properties: {
+					title: { type: 'boolean' },
+					artist: { type: 'boolean' },
+					year: { type: 'boolean' }
+				}
+			}
+		}
+	}
+};
+
+function normalizeValidationResult(raw) {
+	return {
+		verdict: raw?.verdict === 'accepted' ? 'accepted' : 'rejected',
+		confidence: Number.isFinite(raw?.confidence) ? Math.max(0, Math.min(1, Number(raw.confidence))) : 0,
+		rationale: String(raw?.rationale ?? 'Validation IA indisponible.'),
+		normalizedAnswer: {
+			title: raw?.normalizedAnswer?.title ? String(raw.normalizedAnswer.title) : null,
+			artist: raw?.normalizedAnswer?.artist ? String(raw.normalizedAnswer.artist) : null,
+			year: Number.isFinite(raw?.normalizedAnswer?.year) ? Number(raw.normalizedAnswer.year) : null
+		},
+		checks: {
+			title: Boolean(raw?.checks?.title),
+			artist: Boolean(raw?.checks?.artist),
+			year: Boolean(raw?.checks?.year)
+		},
+		source: 'llm'
+	};
+}
+
+function parseStructuredOutput(payload) {
+	const directContent = payload?.choices?.[0]?.message?.content;
+	if (typeof directContent === 'string' && directContent.trim()) {
+		return JSON.parse(directContent);
+	}
+
+	const refusal = payload?.choices?.[0]?.message?.refusal;
+	if (refusal) {
+		throw Object.assign(new Error('llm_refused_request'), { code: 'llm_refused_request' });
+	}
+
+	throw Object.assign(new Error('llm_invalid_response'), { code: 'llm_invalid_response' });
+}
+
+export function createLlmAnswerValidatorService({ apiKey, model, timeoutMs = 8000 }) {
+	const enabled = Boolean(apiKey && model);
+
+	async function validateAnswer({ currentRound, playerAnswerText }) {
+		if (!enabled) {
+			throw Object.assign(new Error('llm_validation_not_configured'), { code: 'llm_validation_not_configured' });
+		}
+
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+		try {
+			const response = await fetch('https://api.openai.com/v1/chat/completions', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${apiKey}`
+				},
+				body: JSON.stringify({
+					model,
+					temperature: 0,
+					response_format: {
+						type: 'json_schema',
+						json_schema: JSON_SCHEMA
+					},
+					messages: [
+						{
+							role: 'system',
+							content: 'Tu es un juge de blind test. Evalue si la reponse du joueur est correcte, en tolérant les variantes usuelles (ponctuation, accents, ordre des mots).'
+						},
+						{
+							role: 'user',
+							content: `Verite terrain:\n- Titre: ${currentRound.title}\n- Artiste: ${currentRound.artist}\n- Annee: ${currentRound.year}\n\nReponse libre du joueur:\n${playerAnswerText}`
+						}
+					]
+				}),
+				signal: controller.signal
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				throw Object.assign(new Error(`llm_http_error_${response.status}: ${errorText}`), {
+					code: 'llm_http_error',
+					status: response.status
+				});
+			}
+
+			const payload = await response.json();
+			const parsed = parseStructuredOutput(payload);
+			return normalizeValidationResult(parsed);
+		} catch (error) {
+			if (error.name === 'AbortError') {
+				throw Object.assign(new Error('llm_timeout'), { code: 'llm_timeout' });
+			}
+			throw error;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	return {
+		enabled,
+		validateAnswer
+	};
+}


### PR DESCRIPTION
### Motivation
- Allow automatic validation of free-text player answers by calling an LLM and returning a deterministic, machine-readable verdict. 
- Enforce a strict JSON schema from the model so the server can safely normalize and act on the result (`accepted`/`rejected`, confidence, rationale, normalized fields, checks). 
- Keep the existing admin/game scoring flow while exposing an API to trigger AI-based decisions for integration or automated play.

### Description
- Add a new service `server/services/llm-answer-validator.js` that sends a single chat prompt (current round truth + player free-text answer) to the model, requests a `json_schema` response, parses and normalizes the returned object, and surfaces errors for timeout/refusal/HTTP failure via specific error codes. The service exposes `createLlmAnswerValidatorService({ apiKey, model, timeoutMs })` with `.enabled` and `.validateAnswer()`.
- Wire the service into server bootstrap (`server/index.js`) and add new config variables in `server/config.js`: `OPENAI_API_KEY`, `ANSWER_VALIDATION_MODEL`, and `ANSWER_VALIDATION_TIMEOUT_MS` to enable/configure the feature.
- Add a new admin route `POST /admin/api/sessions/:id/decision/ai` in `server/routes/admin-session-routes.js` that: loads the current buzz and answer text, calls the LLM validator, applies the returned `verdict` through the existing `gameService.applyDecision` scoring flow, and returns a machine-processable response containing `decision`, `aiValidation`, `ranking`, `scoreDelta`, and `playerId`.
- Extend the player buzz API (`POST /sessions/:id/buzz` in `server/routes/player-routes.js`) to accept either a structured `proposal` object or a free-text `proposal` string and normalize it into a consistent shape for storage and LLM consumption.
- Update documentation in `README.md` and `server/README.md` to document the new environment variables and the new `POST /admin/api/sessions/:id/decision/ai` endpoint and to note that `POST /sessions/:id/buzz` accepts free-text proposals.

### Testing
- Ran the project syntax check with `npm run check` (which runs `node --check server/index.js`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58e1c12b0832aa3489a42d2e06555)